### PR TITLE
Workoutplan page

### DIFF
--- a/app/assets/stylesheets/components/_accordin.scss
+++ b/app/assets/stylesheets/components/_accordin.scss
@@ -4,3 +4,11 @@
   background-position: center;
   height: 200px;
 }
+
+.accordion-card {
+  background-color: #d9dfda;
+  }
+
+.border-black {
+  border: 1px solid #212A31;
+}

--- a/app/assets/stylesheets/components/_lock.scss
+++ b/app/assets/stylesheets/components/_lock.scss
@@ -1,5 +1,4 @@
 .locked {
-  background-color: #f0f0f0;
   color: #999;
   pointer-events: none; /* This disables clicks and other interactions */
 }

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -9,10 +9,12 @@ class PlansController < ApplicationController
 
   def create
     user = current_user
-    plan = Plan.new()
-    workout_plan = plan.create_plan(user)
-    if plan = WorkoutPlanService.create_plan(user.id, workout_plan)
-      redirect_to plan_path(plan), notice: "New Workout plan created"
+    result = Plan.check_and_handle_existing_plan(user)
+    case result[:status]
+    when :existing
+      redirect_to plan_path(result[:plan]), alert: "Existing Plan still not completed"
+    when :created
+      redirect_to plan_path(result[:plan]), notice: "New Workout Plan created"
     end
   end
 

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -12,7 +12,7 @@ class PlansController < ApplicationController
     plan = Plan.new()
     workout_plan = plan.create_plan(user)
     if plan = WorkoutPlanService.create_plan(user.id, workout_plan)
-      redirect_to plan_path(plan), alert: "New Workout plan created"
+      redirect_to plan_path(plan), notice: "New Workout plan created"
     end
   end
 

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,5 +1,6 @@
 import { Application } from "@hotwired/stimulus"
 
+
 const application = Application.start()
 
 // Configure Stimulus development experience

--- a/app/javascript/controllers/autofocus_controller.js
+++ b/app/javascript/controllers/autofocus_controller.js
@@ -4,6 +4,5 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   connect() {
     this.element.focus();
-    console.log(this.element);
   }
 }

--- a/app/javascript/controllers/autofocus_controller.js
+++ b/app/javascript/controllers/autofocus_controller.js
@@ -2,12 +2,13 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-
-   connect() {
-    console.log(this.element)
-     setTimeout(() => {
-       this.element.focus();
-     });
-
-   }
+  static values = { currentDay: Number }
+  connect() {
+    const index = parseInt(this.element.dataset.index);
+    if (index + 1 === this.currentDayValue) {
+      setTimeout(() => {
+              this.element.focus();
+            }, 100);
+    }
+  }
 }

--- a/app/javascript/controllers/autofocus_controller.js
+++ b/app/javascript/controllers/autofocus_controller.js
@@ -2,17 +2,13 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static target = ["collapseElement"]
+  // static target = ["collapseElement"]
 
   connect() {
-    this.element.focus();
+    // this.element.focus();
+    setTimeout(() => {
+      this.element.focus();
+    }, 100);
 
   }
-
-  fire(){
-    this.element.focus();
-    console.log("hi")
-  }
-
-      // Remove focus from other elements
 }

--- a/app/javascript/controllers/autofocus_controller.js
+++ b/app/javascript/controllers/autofocus_controller.js
@@ -4,5 +4,6 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   connect() {
     this.element.focus();
+    console.log("hi")
   }
 }

--- a/app/javascript/controllers/autofocus_controller.js
+++ b/app/javascript/controllers/autofocus_controller.js
@@ -1,0 +1,9 @@
+// app/javascript/controllers/autofocus_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.element.focus();
+    console.log(this.element);
+  }
+}

--- a/app/javascript/controllers/autofocus_controller.js
+++ b/app/javascript/controllers/autofocus_controller.js
@@ -2,13 +2,12 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  // static target = ["collapseElement"]
 
-  connect() {
-    // this.element.focus();
-    setTimeout(() => {
-      this.element.focus();
-    }, 100);
+   connect() {
+    console.log(this.element)
+     setTimeout(() => {
+       this.element.focus();
+     });
 
-  }
+   }
 }

--- a/app/javascript/controllers/autofocus_controller.js
+++ b/app/javascript/controllers/autofocus_controller.js
@@ -2,8 +2,17 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static target = ["collapseElement"]
+
   connect() {
+    this.element.focus();
+
+  }
+
+  fire(){
     this.element.focus();
     console.log("hi")
   }
+
+      // Remove focus from other elements
 }

--- a/app/javascript/controllers/clickfocus_controller.js
+++ b/app/javascript/controllers/clickfocus_controller.js
@@ -1,0 +1,14 @@
+// app/javascript/controllers/autofocus_controller.js
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  // static target = ["collapseElement"]
+  focus(event) {
+    const collapseId = event.currentTarget.getAttribute("data-bs-target");
+    const collapseElement = document.querySelector(collapseId);
+    console.log(collapseId)
+    setTimeout(() => {
+      collapseElement.focus();
+    });
+  }
+}

--- a/app/javascript/controllers/clickfocus_controller.js
+++ b/app/javascript/controllers/clickfocus_controller.js
@@ -9,6 +9,6 @@ export default class extends Controller {
     console.log(collapseId)
     setTimeout(() => {
       collapseElement.focus();
-    });
+    }, 100);
   }
 }

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -20,7 +20,7 @@ class Plan < ApplicationRecord
   end
 
   def self.check_and_handle_existing_plan(user)
-    active_plan = Plan.where("progress < ?", 100).last
+    active_plan = Plan.where(user: user).where("progress < ?", 100).last
     if active_plan
       return { status: :existing, plan: active_plan }
     else

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -19,6 +19,20 @@ class Plan < ApplicationRecord
     rest = ExercisePlan.find_by(status: "rest")
   end
 
+  def self.check_and_handle_existing_plan(user)
+    active_plan = Plan.where("progress < ?", 100).last
+    if active_plan
+      return { status: :existing, plan: active_plan }
+    else
+      plan = Plan.new
+      workout_plan = plan.create_plan(user)
+      new_plan = WorkoutPlanService.create_plan(user.id, workout_plan)
+      if new_plan
+        return { status: :created, plan: new_plan }
+      end
+    end
+  end
+
   def create_plan(user)
     client = OpenAI::Client.new
     content = <<~PROMPT

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -8,10 +8,12 @@ class Plan < ApplicationRecord
   end
 
   def progress_status
-    rest_exercise_plans = self.exercise_plans.where(status: "rest").count
-    total_exercise_plans = ((self.exercise_plans.count) - rest_exercise_plans).to_f
-    completed_exercise_plans = (self.exercise_plans.where(status: "Complete").count).to_f
-    progress = ((completed_exercise_plans / total_exercise_plans).to_f) * 100
+
+    rest_exercise_plans = self.exercise_plans.where(description: "Rest Day").count
+    total_group_exercise_plans = (((self.exercise_plans.group_by(&:suggested_day)).count) - rest_exercise_plans).to_f
+    complete_exercise_plans = self.exercise_plans.where(status: "Complete")
+    group_complete_exercise_plans = (complete_exercise_plans.group_by(&:suggested_day).count).to_f
+    progress = ((group_complete_exercise_plans / total_group_exercise_plans).to_f) * 100
   end
 
   def rest_day

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -8,10 +8,9 @@ class Plan < ApplicationRecord
   end
 
   def progress_status
-
-    rest_exercise_plans = self.exercise_plans.where(description: "Rest Day").count
-    total_group_exercise_plans = (((self.exercise_plans.group_by(&:suggested_day)).count) - rest_exercise_plans).to_f
-    complete_exercise_plans = self.exercise_plans.where(status: "Complete")
+    rest_exercise_plans = exercise_plans.where(description: "Rest Day").count
+    total_group_exercise_plans = (((exercise_plans.group_by(&:suggested_day)).count) - rest_exercise_plans).to_f
+    complete_exercise_plans = exercise_plans.where(status: "Complete")
     group_complete_exercise_plans = (complete_exercise_plans.group_by(&:suggested_day).count).to_f
     progress = ((group_complete_exercise_plans / total_group_exercise_plans).to_f) * 100
   end

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -15,8 +15,7 @@ class Plan < ApplicationRecord
   end
 
   def rest_day
-    rest = self.exercise_plans.find_by(status: "rest")
-    rest_day = rest.suggested_day
+    rest = ExercisePlan.find_by(status: "rest")
   end
 
   def create_plan(user)

--- a/app/views/pages/_user_progress.html.erb
+++ b/app/views/pages/_user_progress.html.erb
@@ -39,7 +39,7 @@
       <% statuses = exercise_plan.map { |plan| plan.status } %>
       <% if  order <= 3 %>
         <%# current_user.current_plan.update!(current_day: days) if order ==1 %>
-        <% if statuses.include?(nil) %>
+        <% if statuses.include?(nil) || statuses.include?("rest") %>
           <%# edit here %>
           <%# url = find_url(current_user.current_plan.exercise_plans.first.description) %>
           <% image_url = ExerciseImage::find_url(exercise_plan.first['description']) %>

--- a/app/views/plans/_active_exercise.html.erb
+++ b/app/views/plans/_active_exercise.html.erb
@@ -1,5 +1,5 @@
 <%= link_to plan_exercise_plan_path(exercise_plan.plan, exercise_plan), class: "text-decoration-none text-black" do %>
-  <div class="accordion-body border rounded-3">
+  <div class="accordion-body border-black" >
     <strong>💪 Exercise <%= exercise_plan.order %>: <%= exercise_plan.exercise.title %></strong>
   </div>
 <% end %>

--- a/app/views/plans/_active_exercise.html.erb
+++ b/app/views/plans/_active_exercise.html.erb
@@ -1,0 +1,5 @@
+<%= link_to plan_exercise_plan_path(exercise_plan.plan, exercise_plan), class: "text-decoration-none text-black" do %>
+  <div class="accordion-body border rounded-3">
+    <strong>💪 Exercise <%= exercise_plan.order %>: <%= exercise_plan.exercise.title %></strong>
+  </div>
+<% end %>

--- a/app/views/plans/_complete_exercise.html.erb
+++ b/app/views/plans/_complete_exercise.html.erb
@@ -1,6 +1,6 @@
 
 <%= link_to(plan_exercise_plan_path(exercise_plan.plan, exercise_plan), {class: "text-decoration-none text-black"}) do %>
-  <div class="accordion-body border rounded-3">
+  <div class="accordion-body border-black">
     <strong class = "completed">✅Exercise <%= exercise_plan.order%>: <%= exercise_plan.exercise.title %></strong>
   </div>
 <% end %>

--- a/app/views/plans/_complete_exercise.html.erb
+++ b/app/views/plans/_complete_exercise.html.erb
@@ -1,0 +1,6 @@
+
+<%= link_to(plan_exercise_plan_path(exercise_plan.plan, exercise_plan), {class: "text-decoration-none text-black"}) do %>
+  <div class="accordion-body border rounded-3">
+    <strong class = "completed">✅Exercise <%= exercise_plan.order%>: <%= exercise_plan.exercise.title %></strong>
+  </div>
+<% end %>

--- a/app/views/plans/_day_condition.html.erb
+++ b/app/views/plans/_day_condition.html.erb
@@ -1,0 +1,16 @@
+  <% if suggested_day < @plan.current_day %>
+      <div class= "text-white mx-5">
+      <h2><strong>✅Day <%= suggested_day %> </strong></h2>
+      <p> <strong><%= exercise_plans_by_day.first.description %> </strong></p>
+      </div>
+  <% elsif suggested_day == @plan.current_day %>
+      <div class= "text-white mx-5">
+      <h2><strong>💪Day <%= suggested_day %> </strong></h2>
+      <p> <strong><%= exercise_plans_by_day.first.description %> </strong></p>
+      </div>
+  <% else%>
+      <div class= " mx-5 locked">
+      <h2><strong>🔐Day <%= suggested_day %> </strong></h2>
+      <p> <strong><%= exercise_plans_by_day.first.description %> </strong></p>
+      </div>
+  <% end %>

--- a/app/views/plans/_exercise_condition.html.erb
+++ b/app/views/plans/_exercise_condition.html.erb
@@ -5,6 +5,7 @@
   <% elsif exercise_plan.status == "Complete"  %>
     <%= render "plans/complete_exercise", exercise_plan: exercise_plan %>
   <% elsif @plan.current_day == @plan.rest_day && @plan.current_day < 7%>
+     <% sleep 5 %> <!-- 5-second delay -->
     <% @plan.update!(current_day: @plan.current_day + 1 ) %>
   <% else %>
     <%= render "plans/lock_exercise", exercise_plan: exercise_plan %>

--- a/app/views/plans/_exercise_condition.html.erb
+++ b/app/views/plans/_exercise_condition.html.erb
@@ -4,7 +4,7 @@
     <% @exercise_rendered = true %>
   <% elsif exercise_plan.status == "Complete"  %>
     <%= render "plans/complete_exercise", exercise_plan: exercise_plan %>
-  <% elsif @plan.current_day == @plan.rest_day %>
+  <% elsif @plan.current_day == @plan.rest_day && @plan.current_day < 7%>
     <% @plan.update!(current_day: @plan.current_day + 1 ) %>
   <% else %>
     <%= render "plans/lock_exercise", exercise_plan: exercise_plan %>

--- a/app/views/plans/_exercise_condition.html.erb
+++ b/app/views/plans/_exercise_condition.html.erb
@@ -1,0 +1,12 @@
+<% if exercise_plan.exercise.description != "Rest day" %>
+  <% if !@exercise_rendered && exercise_plan.status.nil? && exercise_plan.suggested_day == @plan.current_day %>
+    <%= render "plans/active_exercise", exercise_plan: exercise_plan %>
+    <% @exercise_rendered = true %>
+  <% elsif exercise_plan.status == "Complete"  %>
+    <%= render "plans/complete_exercise", exercise_plan: exercise_plan %>
+  <% elsif @plan.current_day == @plan.rest_day %>
+    <% @plan.update!(current_day: @plan.current_day + 1 ) %>
+  <% else %>
+    <%= render "plans/lock_exercise", exercise_plan: exercise_plan %>
+  <% end %>
+<% end %>

--- a/app/views/plans/_lock_exercise.html.erb
+++ b/app/views/plans/_lock_exercise.html.erb
@@ -1,6 +1,6 @@
 
 <%= link_to(plan_exercise_plan_path(exercise_plan.plan, exercise_plan), {class: "text-decoration-none text-black"}) do %>
-  <div class="accordion-body border rounded-3 ">
+  <div class="accordion-body border-black ">
     <strong class = "locked">🔐Exercise <%= exercise_plan.order%>: <%= exercise_plan.exercise.title %></strong>
   </div>
 <% end %>

--- a/app/views/plans/_lock_exercise.html.erb
+++ b/app/views/plans/_lock_exercise.html.erb
@@ -1,0 +1,6 @@
+
+<%= link_to(plan_exercise_plan_path(exercise_plan.plan, exercise_plan), {class: "text-decoration-none text-black"}) do %>
+  <div class="accordion-body border rounded-3 ">
+    <strong class = "locked">🔐Exercise <%= exercise_plan.order%>: <%= exercise_plan.exercise.title %></strong>
+  </div>
+<% end %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -6,14 +6,11 @@
           <h2 class="accordion-header accordion-card pb-1">
             <%# use the ai-generate image service %>
             <%# url =  WorkoutPlanService::set_image (exercise_plans_by_day.first.description) %>
-            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<%= index %>" aria-expanded="true" aria-controls="collapse<%= index %>">
-              <div class= "text-white mx-5">
-              <h2><strong>Day <%= suggested_day %> </strong></h2>
-              <p> <strong><%= exercise_plans_by_day.first.description %> </strong></p>
-              </div>
+            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<%= index %>" aria-expanded="true" aria-controls="collapse<%= index %>" data-action="click->autofocus#fire">
+             <%= render "plans/day_condition", exercise_plans_by_day: exercise_plans_by_day, suggested_day: suggested_day%>
             </button>
           </h2>
-          <div id="collapse<%= index %>" class="accordion-collapse collapse<%= index + 1 == @plan.current_day ? ' show' : '' %>" aria-labelledby="heading<%= index %>" data-bs-parent="#accordionExample" data-controller="autofocus"  tabindex="0">
+          <div id="collapse<%= index %>" class="accordion-collapse collapse<%= index + 1 == @plan.current_day ? ' show' : '' %>" aria-labelledby="heading<%= index %>" data-bs-parent="#accordionExample"  data-controller="autofocus"  tabindex="0" >
             <% exercise_plans_by_day.each_with_index do |exercise_plan, exercise_plan_index| %>
               <%= render "plans/exercise_condition", exercise_plan: exercise_plan, exercise_plan_index: exercise_plan_index %>
             <% end %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -2,7 +2,7 @@
   <div class="accordion" id="accordionExample">
     <div class="accordion-item ">
       <% @exercise_plans_by_day.each_with_index do |(suggested_day, exercise_plans_by_day), index| %>
-        <div class="collape " data-controller="autofocus"  >
+        <div class="collape " >
           <h2 class="accordion-header accordion-card pb-1">
             <%# use the ai-generate image service %>
             <% url =  WorkoutPlanService::set_image (exercise_plans_by_day.first.description) %>
@@ -10,7 +10,7 @@
              <%= render "plans/day_condition", exercise_plans_by_day: exercise_plans_by_day, suggested_day: suggested_day%>
             </button>
           </h2>
-          <div id="collapse<%= index %>" class="accordion-collapse collapse<%= index + 1 == @plan.current_day ? ' show' : '' %>" aria-labelledby="heading<%= index %>" data-bs-parent="#accordionExample"  data-controller="autofocus"  tabindex="0" >
+          <div id="collapse<%= index %>" class="accordion-collapse collapse<%= index + 1 == @plan.current_day ? ' show' : '' %>" aria-labelledby="heading<%= index %>" data-bs-parent="#accordionExample"  data-controller="autofocus"  tabindex="0" data-index="<%= index %>" data-autofocus-current-day-value="<%= @plan.current_day %>">
             <% exercise_plans_by_day.each_with_index do |exercise_plan, exercise_plan_index| %>
               <%= render "plans/exercise_condition", exercise_plan: exercise_plan, exercise_plan_index: exercise_plan_index %>
             <% end %>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -1,16 +1,14 @@
 <div class = "container mt-5">
   <div class="accordion" id="accordionExample">
-    <div class="accordion-item">
+    <div class="accordion-item ">
       <% @exercise_plans_by_day.each_with_index do |(suggested_day, exercise_plans_by_day), index| %>
-        <div class="collape">
-          <h2 class="accordion-header py-2">
+        <div class="collape ">
+          <h2 class="accordion-header accordion-card pb-1">
             <%# use the ai-generate image service %>
-            <% url =  WorkoutPlanService::set_image (exercise_plans_by_day.first.description) %>
-            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<%= index %>" aria-expanded="true" aria-controls="collapse<%= index %>" style="background-image: url('<%= url %>')">
+            <%# url =  WorkoutPlanService::set_image (exercise_plans_by_day.first.description) %>
+            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<%= index %>" aria-expanded="true" aria-controls="collapse<%= index %>">
               <div class= "text-white mx-5">
-              <h2>
-                <strong>Day <%= suggested_day %> </strong>
-              </h2>
+              <h2><strong>Day <%= suggested_day %> </strong></h2>
               <p> <strong><%= exercise_plans_by_day.first.description %> </strong></p>
               </div>
             </button>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -2,11 +2,11 @@
   <div class="accordion" id="accordionExample">
     <div class="accordion-item ">
       <% @exercise_plans_by_day.each_with_index do |(suggested_day, exercise_plans_by_day), index| %>
-        <div class="collape ">
+        <div class="collape " data-controller="autofocus"  >
           <h2 class="accordion-header accordion-card pb-1">
             <%# use the ai-generate image service %>
             <% url =  WorkoutPlanService::set_image (exercise_plans_by_day.first.description) %>
-            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<%= index %>" aria-expanded="true" aria-controls="collapse<%= index %>" style="background-image: url('<%= url %>')">
+            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<%= index %>" aria-expanded="true" aria-controls="collapse<%= index %>" style="background-image: url('<%= url %>')" data-action="click->clickfocus#focus" data-controller="clickfocus">
              <%= render "plans/day_condition", exercise_plans_by_day: exercise_plans_by_day, suggested_day: suggested_day%>
             </button>
           </h2>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -6,49 +6,18 @@
           <h2 class="accordion-header py-2">
             <%# use the ai-generate image service %>
             <% url =  WorkoutPlanService::set_image (exercise_plans_by_day.first.description) %>
-            <%#=style="background-image: url('<%= url >')" %>
-
             <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<%= index %>" aria-expanded="true" aria-controls="collapse<%= index %>" style="background-image: url('<%= url %>')">
               <div class= "text-white mx-5">
               <h2>
-                <strong>Day: <%= suggested_day %> </strong>
+                <strong>Day <%= suggested_day %> </strong>
               </h2>
-              <p> <strong>Description: <%= exercise_plans_by_day.first.description %> </strong></p>
+              <p> <strong><%= exercise_plans_by_day.first.description %> </strong></p>
               </div>
             </button>
           </h2>
-          <div id="collapse<%= index %>" class="accordion-collapse collapse<%= index + 1 == @plan.current_day  ? ' show' : '' %>" aria-labelledby="heading<%= index %>" data-bs-parent="#accordionExample" <%= 'autofocus' if index + 1 == @plan.current_day %>>
-            <% active_num = 1 %>
+          <div id="collapse<%= index %>" class="accordion-collapse collapse<%= index + 1 == @plan.current_day ? ' show' : '' %>" aria-labelledby="heading<%= index %>" data-bs-parent="#accordionExample" data-controller="autofocus"  tabindex="0">
             <% exercise_plans_by_day.each_with_index do |exercise_plan, exercise_plan_index| %>
-            <% if exercise_plan.exercise.description != "Rest day" %>
-
-              <% if exercise_plan.status == nil && active_num == 1 && exercise_plan.suggested_day == @plan.current_day%>
-                <%= link_to(plan_exercise_plan_path(exercise_plan.plan, exercise_plan), {class: "text-decoration-none text-black"}) do %>
-                <div class="accordion-body border rounded-3">
-                  <strong>💪Exercise <%= exercise_plan.order%>: <%= exercise_plan.exercise.title %></strong>
-                  <% active_num += 1 %>
-                  </div>
-                <% end %>
-              <% elsif exercise_plan.status == "Complete"  %>
-                <%= link_to(plan_exercise_plan_path(exercise_plan.plan, exercise_plan), {class: "text-decoration-none text-black"}) do %>
-                <div class="accordion-body border rounded-3">
-                  <strong class = "completed">✅Exercise <%= exercise_plan.order%>: <%= exercise_plan.exercise.title %></strong>
-                  <% active_num = 1 %>
-                  </div>
-                <% end %>
-
-              <% elsif @plan.current_day == @plan.rest_day %>
-
-                <% @plan.update!(current_day: @plan.current_day + 1 ) %>
-              <% else %>
-                <%= link_to(plan_exercise_plan_path(exercise_plan.plan, exercise_plan), {class: "text-decoration-none text-black"}) do %>
-                <div class="accordion-body border rounded-3 ">
-                  <strong class = "locked">🔐Exercise <%= exercise_plan.order%>: <%= exercise_plan.exercise.title %></strong>
-                  </div>
-                <% end %>
-
-                <% end %>
-              <% end %>
+              <%= render "plans/exercise_condition", exercise_plan: exercise_plan, exercise_plan_index: exercise_plan_index %>
             <% end %>
           </div>
         </div>
@@ -56,18 +25,3 @@
     </div>
   </div>
 </div>
-<script>
-  document.addEventListener('DOMContentLoaded', function () {
-    var focusButton = document.querySelector('.focus-item');
-    console.log(focusButton);
-    if (focusButton) {
-      focusButton.click(); // Open the focused item
-      setTimeout(function() {
-        var panel = focusButton.closest('.accordion-item');
-        if (panel) {
-          panel.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        }
-      }, 100); // Adjust the delay as needed (in milliseconds)
-    }
-  });
-</script>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -5,8 +5,8 @@
         <div class="collape ">
           <h2 class="accordion-header accordion-card pb-1">
             <%# use the ai-generate image service %>
-            <%# url =  WorkoutPlanService::set_image (exercise_plans_by_day.first.description) %>
-            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<%= index %>" aria-expanded="true" aria-controls="collapse<%= index %>" data-action="click->autofocus#fire">
+            <% url =  WorkoutPlanService::set_image (exercise_plans_by_day.first.description) %>
+            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse<%= index %>" aria-expanded="true" aria-controls="collapse<%= index %>" style="background-image: url('<%= url %>')">
              <%= render "plans/day_condition", exercise_plans_by_day: exercise_plans_by_day, suggested_day: suggested_day%>
             </button>
           </h2>


### PR DESCRIPTION
1. Homepage (user) - Current plan progress -> Adjust to calculate by day completed instead of exercise plan completed.
2. Homepage (user) - The rest day able to show at the latest 3 days card. (no skip to show the rest day in list)
3. Plan Page: - Container -> Remove redundant container
4. Plan Page - Exercise in days -> Adjust spacing and background color
5. Plan Page - Day card: Remove ":" and "Description:"
6. Plan Page - Day card: Grey text color if not current day, for completed day had mark ✅
7. Plan Page - Add the autofocus stimulus controller to focus the current workout page once refresh or link to the workout page.
8. Add the workout plan - Apply the logic the disable the user for create multiple active workout plan. One user only able to create one active workout plan.
